### PR TITLE
Updated wrong types in `quantile_plot.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Version X.Y.Z stands for:
 
 -------------
 
+## Version 3.1.6
+
+### Changes
+- Updated wrong types in `quantile_plot.py`
+
 ## Version 3.1.5
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "sam"
-version = "3.1.5"
+version = "3.1.6"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/sam/visualization/quantile_plot.py
+++ b/sam/visualization/quantile_plot.py
@@ -7,7 +7,7 @@ COLORS = ["#2453bd", "#7497e3", "#c3d0eb", "#d1d8e8"]
 
 
 def sam_quantile_plot(
-    y_true: pd.DataFrame,
+    y_true: pd.Series,
     y_hat: pd.DataFrame,
     title: str = None,
     y_title: str = "",
@@ -38,8 +38,8 @@ def sam_quantile_plot(
 
     Parameters
     ---------
-    y_true: pd.DataFrame
-        Pandas DataFrame with single row (the actual values) should have same index as y_hat.
+    y_true: pd.Series
+        Pandas Series containing the actual values. Should have same index as y_hat.
     y_hat: pd.DataFrame
         Dataframe returned by the MLPTimeseriesRegressor .predict() function.
         Columns should contain at least `predict_lead_x_mean`, where x is predict ahead
@@ -178,7 +178,7 @@ def sam_quantile_plot(
 
 
 def _interactive_quantile_plot(
-    y_true: pd.DataFrame,
+    y_true: pd.Series,
     y_hat: pd.DataFrame,
     title: str = None,
     y_title: str = "",
@@ -309,7 +309,7 @@ def _interactive_quantile_plot(
 
 
 def _static_quantile_plot(
-    y_true: pd.DataFrame,
+    y_true: pd.Series,
     y_hat: pd.DataFrame,
     title: str = None,
     y_title: str = "",


### PR DESCRIPTION
Type for y_true was set to pd.DataFrame, while a few lines later in `sam_quantile_plot`, `y_true.name` is checked. This caused the function to break, since pd.Dataframe has no attribute name, but pd.Series does. Since y_true was supposed to be a DataFrame with 1 column, this change is backwards compatible when `y_title`is provided.