### PR TITLE
Updated BaseTimeseriesRegressor.get_feature_names_out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Version X.Y.Z stands for:
 
 -------------
 
+## Version 3.1.7
+
+### Changes
+- Updated `BaseTimeseriesRegressor.get_feature_names_out()` so, in case of the feature engineer is a `Pipeline`, it returns the names from the last `ColumnTransformer`, if available
+
 ## Version 3.1.6
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "sam"
-version = "3.1.6"
+version = "3.1.7"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/sam/models/base_model.py
+++ b/sam/models/base_model.py
@@ -490,7 +490,8 @@ class BaseTimeseriesRegressor(BaseEstimator, RegressorMixin, ABC):
         It is assumed that in case of Pipelines for feature engineer, the last
         ColumnTransformer step contains the feature names. If any element from
         the Pipeline is an instance of ColumnTransformer, the last step is used for
-        getting the feature names
+        getting the feature names. If any step is a instance of ColumnTransformer, the last
+        element of the Pipeline with the method `get_feature_names_out` is used.
 
         Returns
         -------

--- a/sam/models/base_model.py
+++ b/sam/models/base_model.py
@@ -490,7 +490,7 @@ class BaseTimeseriesRegressor(BaseEstimator, RegressorMixin, ABC):
         It is assumed that in case of Pipelines for feature engineer, the last
         ColumnTransformer step contains the feature names. If any element from
         the Pipeline is an instance of ColumnTransformer, the last step is used for
-        getting the feature names. If any step is a instance of ColumnTransformer, the last
+        getting the feature names. If not any step is a instance of ColumnTransformer, the last
         element of the Pipeline with the method `get_feature_names_out` is used.
 
         Returns

--- a/sam/models/base_model.py
+++ b/sam/models/base_model.py
@@ -11,6 +11,7 @@ from sam.metrics import joint_mae_tilted_loss, joint_mse_tilted_loss
 from sam.preprocessing import inverse_differenced_target, make_shifted_target
 from sam.utils import assert_contains_nans, make_df_monotonic
 from sklearn.base import BaseEstimator, RegressorMixin, TransformerMixin
+from sklearn.compose import ColumnTransformer
 from sklearn.utils.validation import check_is_fitted
 from sklearn.pipeline import Pipeline
 
@@ -486,6 +487,11 @@ class BaseTimeseriesRegressor(BaseEstimator, RegressorMixin, ABC):
         Function for obtaining feature names. Generally used instead of the attribute, and more
         compatible with the sklearn API.
 
+        It is assumed that in case of Pipelines for feature engineer, the last
+        ColumnTransformer step contains the feature names. If any element from
+        the Pipeline is an instance of ColumnTransformer, the last step is used for
+        getting the feature names
+
         Returns
         -------
         list:
@@ -502,6 +508,9 @@ class BaseTimeseriesRegressor(BaseEstimator, RegressorMixin, ABC):
                 if hasattr(step[-1], "get_feature_names_out")
             ]
             if len(feature_steps) > 0:
+                for step in feature_steps[::-1]:
+                    if isinstance(step, ColumnTransformer):
+                        return step.get_feature_names_out()
                 return feature_steps[-1].get_feature_names_out()
             else:
                 raise ValueError(


### PR DESCRIPTION
Updated `BaseTimeseriesRegressor.get_feature_names_out()` so, in case of the feature engineer is a `Pipeline`, it returns the names from the last `ColumnTransformer`, if available