### PR TITLE
Upgrade tensorflow and numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Version X.Y.Z stands for:
 
 -------------
 
+## Version 3.1.10
+
+### Changes
+- Allow numpy versions up to 1.23.x. 1.24 is not yet supported by shap (and shap does not specify this constraint in its requirements). For future reference, note that numpy 1.24 is also not supported by h5py versions below 3.0.0 (again without specifying) as it uses the deprecated `np.typeDict`. h5py is a requirement of tensorflow.
+- Upgrade tensorflow
+- Limit scikit-learn version <2
+
 ## Version 3.1.9
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "sam"
-version = "3.1.9"
+version = "3.1.10"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -35,7 +35,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = ["pandas~=1.3", "numpy>=1.18,<1.22", "scikit-learn>=1.1"]
+dependencies = ["pandas~=1.3", "numpy>=1.22,<1.24", "scikit-learn~=1.1"]
 
 [project.optional-dependencies]
 all = [
@@ -46,8 +46,7 @@ all = [
     "requests",
     "scipy",
     "seaborn",
-    "tensorflow>=2.3.1,<2.9",
-    "protobuf<=3.20.1",
+    "tensorflow>=2.9.1,<3",
     "eli5",
     "Jinja2~=3.0.3",
     "shap",
@@ -57,7 +56,7 @@ all = [
 plotting = ["matplotlib", "plotly", "seaborn"]
 data-engineering = ["requests", "pymongo"]
 data-science = [
-    "tensorflow>=2.3.1,<2.9",
+    "tensorflow>=2.9.1,<3",
     "cloudpickle",
     "nfft",
     "scipy",
@@ -75,7 +74,7 @@ docs = [
     "readthedocs-sphinx-search",
     "sphinx-markdown-tables",
     "toml",
-    "tensorflow>=2.3.1,<2.9",
+    "tensorflow>=2.9.1,<3",
 ]
 
 [project.urls]

--- a/sam/models/mlp_model.py
+++ b/sam/models/mlp_model.py
@@ -323,7 +323,7 @@ class MLPTimeseriesRegressor(BaseTimeseriesRegressor):
             raise ValueError("You must provide y when using use_diff_of_y=True")
 
         X_transformed = self.preprocess_predict(X, y)
-        prediction = self.model_.predict(X_transformed)
+        prediction = self.model_.predict(X_transformed, verbose=self.verbose)
 
         prediction = self.postprocess_predict(
             prediction, X, y, force_monotonic_quantiles=force_monotonic_quantiles
@@ -543,9 +543,9 @@ class MLPTimeseriesRegressor(BaseTimeseriesRegressor):
 
             def score(X, y, model=self.model_):
                 if self.average_type == "median":
-                    return np.mean(np.abs(y - model.predict(X)[:, -1]))
+                    return np.mean(np.abs(y - model.predict(X, verbose=0)[:, -1]))
                 elif self.average_type == "mean":
-                    return np.mean((y - model.predict(X)[:, -1]) ** 2)
+                    return np.mean((y - model.predict(X, verbose=0)[:, -1]) ** 2)
 
         X_transformed = self.preprocess_predict(X, y)
 
@@ -643,8 +643,10 @@ class MLPTimeseriesRegressor(BaseTimeseriesRegressor):
         ...
         >>> model.fit(X_train, y_train)  # doctest: +ELLIPSIS
         <keras.callbacks.History ...
-        >>> explainer = model.get_explainer(X_test, y_test, sample_n=10)
-        >>> shap_values = explainer.shap_values(X_test[0:30], y_test[0:30])
+        >>> ();explainer = model.get_explainer(X_test, y_test, sample_n=10);()  # doctest: +ELLIPSIS
+        (...)
+        >>> ();shap_values = explainer.shap_values(X_test[0:30], y_test[0:30]);()  # doctest: +ELLIPSIS
+        (...)
         >>> test_values = explainer.test_values(X_test[0:30], y_test[0:30])
         >>> shap.force_plot(explainer.expected_value[0], shap_values[0][-1,:],
         ...                 test_values.iloc[-1,:], matplotlib=True)

--- a/sam/models/mlp_model.py
+++ b/sam/models/mlp_model.py
@@ -643,9 +643,11 @@ class MLPTimeseriesRegressor(BaseTimeseriesRegressor):
         ...
         >>> model.fit(X_train, y_train)  # doctest: +ELLIPSIS
         <keras.callbacks.History ...
-        >>> ();explainer = model.get_explainer(X_test, y_test, sample_n=10);()  # doctest: +ELLIPSIS
+        >>> ();explainer = model.get_explainer(X_test, y_test, sample_n=10);()
+        ... # doctest: +ELLIPSIS
         (...)
-        >>> ();shap_values = explainer.shap_values(X_test[0:30], y_test[0:30]);()  # doctest: +ELLIPSIS
+        >>> ();shap_values = explainer.shap_values(X_test[0:30], y_test[0:30]);()
+        ... # doctest: +ELLIPSIS
         (...)
         >>> test_values = explainer.test_values(X_test[0:30], y_test[0:30])
         >>> shap.force_plot(explainer.expected_value[0], shap_values[0][-1,:],


### PR DESCRIPTION
By setting the minimum version of tensorflow to [2.9.1](https://github.com/tensorflow/tensorflow/releases/tag/v2.9.1) we can remove the protobuf dependency.