### PR TITLE
Categorical columns added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Version X.Y.Z stands for:
 
 -------------
 
+## Version 3.1.11
+
+### Changes
+- Make `'ID'`and `'TYPE'` columns `pd.Categorical` instead of `str`, to reduce the memory spike when using `pd.pivot_table` in `sam_format_to_wide`.
+
 ## Version 3.1.10
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version X.Y.Z stands for:
 
 ### Changes
 - Make `'ID'`and `'TYPE'` columns `pd.Categorical` instead of `str`, to reduce the memory spike when using `pd.pivot_table` in `sam_format_to_wide`.
+- Added parameter in `QuantileRegressor` to use HiGHS solver, as recommended in <https://docs.scipy.org/doc/scipy/reference/optimize.linprog-highs.html>. This will also keep the package compatible with future versions of SciPy.
 
 ## Version 3.1.10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ all = [
     "requests",
     "scipy",
     "seaborn",
-    "tensorflow>=2.9.1,<3",
+    "tensorflow>=2.9.1,<2.13.0",
     "eli5",
     "Jinja2~=3.0.3",
     "shap",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = ["pandas~=1.3", "numpy>=1.22,<1.24", "scikit-learn~=1.1"]
+dependencies = ["pandas~=1.3", "numpy>=1.22,<1.24", "scikit-learn~=1.1,<1.3"]
 
 [project.optional-dependencies]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "sam"
-version = "3.1.10"
+version = "3.1.11"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/sam/models/lasso_model.py
+++ b/sam/models/lasso_model.py
@@ -134,6 +134,7 @@ class LassoTimeseriesRegressor(BaseTimeseriesRegressor):
             estimator = QuantileRegressor(
                 quantile=quantile,
                 alpha=self.alpha,
+                solver="highs",
                 fit_intercept=self.fit_intercept,
                 **(self.quantile_options or {}),
             )

--- a/sam/preprocessing/sam_reshape.py
+++ b/sam/preprocessing/sam_reshape.py
@@ -24,7 +24,10 @@ def sam_format_to_wide(data: pd.DataFrame, sep: str = "_"):
         created column names will be 'abc_debiet' and 'abc_stand', as well as TIME. The result
         will be sorted by TIME, ascending. The index will be a range from 0 to `nrows`.
     """
-    data = pd.pivot_table(data, values="VALUE", index=["TIME"], columns=["ID", "TYPE"])
+
+    data['ID'], data['TYPE'] = pd.Categorical(data['ID']), pd.Categorical(data['TYPE'])
+
+    data = pd.pivot_table(data, values="VALUE", index=["TIME"], columns=["ID", "TYPE"], observed=True)
     try:
         data.columns = [
             str(x[0]) + sep + x[1]

--- a/sam/preprocessing/sam_reshape.py
+++ b/sam/preprocessing/sam_reshape.py
@@ -25,9 +25,11 @@ def sam_format_to_wide(data: pd.DataFrame, sep: str = "_"):
         will be sorted by TIME, ascending. The index will be a range from 0 to `nrows`.
     """
 
-    data['ID'], data['TYPE'] = pd.Categorical(data['ID']), pd.Categorical(data['TYPE'])
+    data["ID"], data["TYPE"] = pd.Categorical(data["ID"]), pd.Categorical(data["TYPE"])
 
-    data = pd.pivot_table(data, values="VALUE", index=["TIME"], columns=["ID", "TYPE"], observed=True)
+    data = pd.pivot_table(
+        data, values="VALUE", index=["TIME"], columns=["ID", "TYPE"], observed=True
+    )
     try:
         data.columns = [
             str(x[0]) + sep + x[1]


### PR DESCRIPTION
Make `'ID'`and `'TYPE'` columns `pd.Categorical` instead of `str`, to reduce the memory spike when using `pd.pivot_table` in `sam_format_to_wide`.

According to some tests, using a dataframe of 534.9 MB in sam format, the size is reduced to 352.3 MB when making ID and TYPE categorical. And the memory spike when pivoting that table is reduced by 17% on average. Please, consider that this is an approximated result, due to the difficulty of monitoring memory spikes.

The pandas implementation with categorical variables seems to be more stable, in terms of memory spikes, than alternative implementations in `dask` or `polars`