### PR TITLE
remove keras_templates imports from models __init__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Version X.Y.Z stands for:
 
 -------------
 
+## Version 3.1.12
+
+### Changes
+- Remove `keras_templates` imports from `sam.models` initialization. This will allow users to use certain models that do not depend on tensorflow without having that rather large dependency installed.
+
 ## Version 3.1.11
 
 ### Changes

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -16,10 +16,10 @@ Linear Quantile Regression
 Keras templates
 ---------------------------
 .. _create-keras-quantile-mlp:
-.. autofunction:: sam.models.create_keras_quantile_mlp
-.. autofunction:: sam.models.create_keras_quantile_rnn
-.. autofunction:: sam.models.create_keras_autoencoder_mlp
-.. autofunction:: sam.models.create_keras_autoencoder_rnn
+.. autofunction:: sam.models.keras_templates.create_keras_quantile_mlp
+.. autofunction:: sam.models.keras_templates.create_keras_quantile_rnn
+.. autofunction:: sam.models.keras_templates.create_keras_autoencoder_mlp
+.. autofunction:: sam.models.keras_templates.create_keras_autoencoder_rnn
 
 Statistical process control
 ---------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "sam"
-version = "3.1.11"
+version = "3.1.12"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/sam/metrics/keras_metrics.py
+++ b/sam/metrics/keras_metrics.py
@@ -38,7 +38,7 @@ def keras_tilted_loss(y_true: tf.Tensor, y_pred: tf.Tensor, quantile: float = 0.
     Examples
     --------
     >>> from sam.metrics import keras_tilted_loss
-    >>> from sam.models import create_keras_quantile_mlp
+    >>> from sam.models.keras_templates import create_keras_quantile_mlp
     >>> n_input = 1000
     >>> n_neurons = 64
     >>> n_layers = 3
@@ -87,7 +87,7 @@ def keras_joint_mse_tilted_loss(
     Examples
     --------
     >>> from sam.metrics import keras_joint_mse_tilted_loss as mse_tilted
-    >>> from sam.models import create_keras_quantile_mlp
+    >>> from sam.models.keras_templates import create_keras_quantile_mlp
     >>> n_input = 1000
     >>> n_neurons = 64
     >>> n_layers = 3
@@ -149,7 +149,7 @@ def keras_joint_mae_tilted_loss(
     Examples
     --------
     >>> from sam.metrics import keras_joint_mae_tilted_loss as mae_tilted
-    >>> from sam.models import create_keras_quantile_mlp
+    >>> from sam.models.keras_templates import create_keras_quantile_mlp
     >>> n_input = 1000
     >>> n_neurons = 64
     >>> n_layers = 3
@@ -190,7 +190,7 @@ def keras_rmse(y_true: tf.Tensor, y_pred: tf.Tensor):
     Examples
     --------
     >>> from sam.metrics import keras_rmse
-    >>> from sam.models import create_keras_quantile_mlp
+    >>> from sam.models.keras_templates import create_keras_quantile_mlp
     >>> n_input = 1000
     >>> n_neurons = 64
     >>> n_layers = 3
@@ -218,7 +218,7 @@ def get_keras_forecasting_metrics(quantiles: List[float] = None):
     Examples
     --------
     >>> from sam.metrics import keras_rmse, get_keras_forecasting_metrics
-    >>> from sam.models import create_keras_quantile_mlp
+    >>> from sam.models.keras_templates import create_keras_quantile_mlp
     >>> n_input = 1000
     >>> n_neurons = 64
     >>> n_layers = 3

--- a/sam/models/__init__.py
+++ b/sam/models/__init__.py
@@ -4,12 +4,6 @@ from .benchmark import (
     plot_score_dicts,
     preprocess_data_for_benchmarking,
 )
-from .keras_templates import create_keras_autoencoder_rnn
-from .keras_templates import (
-    create_keras_autoencoder_mlp,
-    create_keras_quantile_mlp,
-    create_keras_quantile_rnn,
-)
 
 from .sam_shap_explainer import SamShapExplainer
 from .linear_model import LinearQuantileRegression
@@ -23,10 +17,6 @@ __all__ = [
     "benchmark_model",
     "plot_score_dicts",
     "preprocess_data_for_benchmarking",
-    "create_keras_autoencoder_rnn",
-    "create_keras_autoencoder_mlp",
-    "create_keras_quantile_mlp",
-    "create_keras_quantile_rnn",
     "SamShapExplainer",
     "LinearQuantileRegression",
     "BaseTimeseriesRegressor",

--- a/sam/models/keras_templates.py
+++ b/sam/models/keras_templates.py
@@ -65,7 +65,7 @@ def create_keras_quantile_mlp(
 
     Examples
     --------
-    >>> from sam.models import create_keras_quantile_mlp
+    >>> from sam.models.keras_templates import create_keras_quantile_mlp
     >>> from sam.datasets import load_rainbow_beach
     >>> data = load_rainbow_beach()
     >>> X, y = data, data["water_temperature"]
@@ -294,7 +294,7 @@ def create_keras_autoencoder_mlp(
     >>> import pandas as pd
     >>> from sam.data_sources import synthetic_date_range, synthetic_timeseries
     >>> from sam.preprocessing import RecurrentReshaper
-    >>> from sam.models import create_keras_autoencoder_mlp
+    >>> from sam.models.keras_templates import create_keras_autoencoder_mlp
     >>> dates = pd.Series(synthetic_date_range().to_pydatetime())
     >>> X = [synthetic_timeseries(dates, daily=2, noise={'normal': 0.25}, seed=i)
     ...      for i in range(100)]
@@ -393,7 +393,7 @@ def create_keras_autoencoder_rnn(
     >>> import pandas as pd
     >>> from sam.data_sources import synthetic_date_range, synthetic_timeseries
     >>> from sam.preprocessing import RecurrentReshaper
-    >>> from sam.models import create_keras_autoencoder_rnn
+    >>> from sam.models.keras_templates import create_keras_autoencoder_rnn
     >>> dates = pd.Series(synthetic_date_range().to_pydatetime())
     >>> y = synthetic_timeseries(dates, daily=2, noise={'normal': 0.25}, seed=2)
     >>> X = pd.DataFrame(y)

--- a/sam/models/mlp_model.py
+++ b/sam/models/mlp_model.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from sam.feature_engineering import BaseFeatureEngineer
 from sam.metrics import R2Evaluation, keras_joint_mse_tilted_loss
-from sam.models import create_keras_quantile_mlp
+from sam.models.keras_templates import create_keras_quantile_mlp
 from sam.models.base_model import BaseTimeseriesRegressor
 from sam.preprocessing import make_shifted_target
 from sklearn.base import TransformerMixin
@@ -169,7 +169,7 @@ class MLPTimeseriesRegressor(BaseTimeseriesRegressor):
     def get_untrained_model(self) -> Callable:
         """
         Returns a simple 2d keras model.
-        This is just a wrapper for sam.models.create_keras_quantile_mlp
+        This is just a wrapper for sam.models.keras_templates.create_keras_quantile_mlp
 
         Overwrites the abstract method from BaseTimeseriesRegressor
         """


### PR DESCRIPTION
in `models` we imported keras functions from `keras_templates` in the `__init__.py`, so even if users of `SAM` want to not use keras they need to have this rather big dependency installed if they want to use, say, a Lasso model.

Only change: Removed the keras imports from the `__init__.py` of `models`.

NOTE: This will affect code where keras methods in SAM are imported directly from `models`.