### PR TITLE
Support3.12

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,11 +13,11 @@ jobs:
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v5
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,7 +6,7 @@ on:
     - main
   push:
     branches:
-    - '*'
+    - 'main'
 
 jobs:
   build:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,7 +6,7 @@ on:
     - main
   push:
     branches:
-    - main
+    - '*'
 
 jobs:
   build:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
       run: |
         pytest --mpl --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
     - name: Code coverage 
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
         flags: unittests # optional

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.9"
+    python: "3.12"
 
 # Build from the docs/ directory with Sphinx
 sphinx:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Version X.Y.Z stands for:
 
 -------------
 
+## Version 6.0.0
+
+### Changes
+- Remove support for python 3.9 and 3.10, and add support for 3.12.
+- User Keras directly instead of tensorflow wrapper. This triggered some changes in the types of the docstrings.
+- Use numpy 2.
+- Fix a few deprecation warnings.
+
 ## Version 5.1.0
 
 ### Changes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ root_folder = Path(__file__).parents[2]
 # -- Project information -----------------------------------------------------
 
 project = "sam"
-copyright = "2018-2023, Royal HaskoningDHV"
+copyright = "2018-2026, Royal HaskoningDHV"
 author = "Royal HaskoningDHV"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = ["pandas~=2.2", "numpy~=1.26", "scikit-learn~=1.5.2"]
+dependencies = ["pandas~=2.2", "numpy~=2.0", "scikit-learn~=1.5.2"]
 
 [project.optional-dependencies]
 all = [
@@ -66,7 +66,7 @@ data-science = [
     "onnxruntime~=1.19.2",
     "tf2onnx~=1.16.1",
     "nfft",
-    "scipy~=1.13.1",
+    "scipy~=1.15.3",
     "shap",
     "Jinja2~=3.0.3",
     "statsmodels"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ all = [
     "nfft",
     "pymongo",
     "requests",
-    "scipy~=1.15.3",
+    "scipy~=1.13.1",
     "seaborn",
     "tensorflow>=2.16,<3",
     "keras>=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "sam"
-version = "5.1.0"
+version = "6.0.0"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ all = [
     "nfft",
     "pymongo",
     "requests",
-    "scipy~=1.13.1",
+    "scipy~=1.15.3",
     "seaborn",
     "tensorflow>=2.16,<3",
     "keras>=3.0",
@@ -66,7 +66,7 @@ data-science = [
     "onnxruntime~=1.19.2",
     "tf2onnx~=1.16.1",
     "nfft",
-    "scipy~=1.13.1",
+    "scipy~=1.15.3",
     "shap",
     "Jinja2~=3.0.3",
     "statsmodels"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ name = "sam"
 version = "5.1.0"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [{name = "Royal HaskoningDHV", email = "ruben.peters@rhdhv.com"}]
 keywords = ["python", "data-science", "time-series", "forecasting", "anomaly-detection", "asset-management"]
@@ -46,7 +46,8 @@ all = [
     "requests",
     "scipy~=1.13.1",
     "seaborn",
-    "tensorflow~=2.17,<3",
+    "tensorflow>=2.16,<3",
+    "keras>=3.0",
     "Jinja2~=3.0.3",
     "onnx~=1.16.1",
     "onnxruntime~=1.19.2",
@@ -58,7 +59,8 @@ all = [
 plotting = ["matplotlib", "plotly", "seaborn"]
 data-engineering = ["requests", "pymongo"]
 data-science = [
-    "tensorflow~=2.17,<3",
+    "tensorflow>=2.16,<3",
+    "keras>=3.0",
     "cloudpickle",
     "onnx~=1.16.1",
     "onnxruntime~=1.19.2",
@@ -78,7 +80,8 @@ docs = [
     "readthedocs-sphinx-search",
     "sphinx-markdown-tables",
     "toml",
-    "tensorflow~=2.17,<3",
+    "tensorflow>=2.16,<3",
+    "keras>=3.0",
 ]
 
 [project.urls]
@@ -89,7 +92,7 @@ documentation = "https://sam-rhdhv.readthedocs.io/en/latest/"
 
 [tool.black]
 line-length = 99
-target-version = ['py39', 'py310']
+target-version = ['py312']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ data-science = [
     "onnxruntime~=1.19.2",
     "tf2onnx~=1.16.1",
     "nfft",
-    "scipy~=1.15.3",
+    "scipy~=1.13.1",
     "shap",
     "Jinja2~=3.0.3",
     "statsmodels"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ name = "sam"
 version = "6.0.0"
 description = "Time series anomaly detection and forecasting"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {text = "MIT"}
 authors = [{name = "Royal HaskoningDHV", email = "ruben.peters@rhdhv.com"}]
 keywords = ["python", "data-science", "time-series", "forecasting", "anomaly-detection", "asset-management"]
@@ -46,8 +46,8 @@ all = [
     "requests",
     "scipy~=1.13.1",
     "seaborn",
-    "tensorflow>=2.16,<3",
-    "keras>=3.0",
+    "tensorflow>=2.17,<3",
+    "keras>=3.0,<4",
     "Jinja2~=3.0.3",
     "onnx~=1.16.1",
     "onnxruntime~=1.19.2",
@@ -59,8 +59,8 @@ all = [
 plotting = ["matplotlib", "plotly", "seaborn"]
 data-engineering = ["requests", "pymongo"]
 data-science = [
-    "tensorflow>=2.16,<3",
-    "keras>=3.0",
+    "tensorflow>=2.17,<3",
+    "keras>=3.0,<4",
     "cloudpickle",
     "onnx~=1.16.1",
     "onnxruntime~=1.19.2",
@@ -80,8 +80,6 @@ docs = [
     "readthedocs-sphinx-search",
     "sphinx-markdown-tables",
     "toml",
-    "tensorflow>=2.16,<3",
-    "keras>=3.0",
 ]
 
 [project.urls]

--- a/sam/__init__.py
+++ b/sam/__init__.py
@@ -5,7 +5,6 @@ import re
 import warnings
 from os.path import isdir
 
-
 warnings.filterwarnings(
     "always", category=DeprecationWarning, module=r"^{0}\.".format(re.escape(__name__))
 )

--- a/sam/datasets/__init__.py
+++ b/sam/datasets/__init__.py
@@ -1,6 +1,5 @@
 from .datasets import load_rainbow_beach, load_sewage_data
 
-
 __all__ = [
     "load_rainbow_beach",
     "load_sewage_data",

--- a/sam/datasets/datasets.py
+++ b/sam/datasets/datasets.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pandas as pd
 
-
 PACKAGEDIR = Path(__file__).parent.absolute()
 
 

--- a/sam/exploration/find_incidents.py
+++ b/sam/exploration/find_incidents.py
@@ -119,7 +119,9 @@ def incident_curves(
     # Find the streaks of gaps. Gaps are defined as anything that's not an outlier
     data["GAP"] = _number_true_streaks(~data["OUTLIER"])
     # Then, all gaps with length of max_gap or lower are merged with neighbouring outliers
-    new_val = data.groupby("GAP").apply(lambda x: True if (x.shape[0] <= max_gap) else False)
+    new_val = data.groupby("GAP").apply(
+        lambda x: True if (x.shape[0] <= max_gap) else False, include_groups=False
+    )
     new_val[0] = True  # because this is not an outlier, it's treated seperately
     new_val.name = "OUTLIER_FILLED"  # Attribute needed for join
     data = data.join(new_val, on="GAP")  # Add OUTLIER_FILLED column
@@ -151,7 +153,8 @@ def incident_curves(
     real_outlier = data.groupby("OUTLIER_CURVE").apply(
         lambda x: (x.shape[0] >= min_duration)
         and (x.OUTLIER_DIST.sum() >= min_dist_total)
-        and (1 - (x.OUTLIER.sum() / x.shape[0]) <= max_gap_perc)
+        and (1 - (x.OUTLIER.sum() / x.shape[0]) <= max_gap_perc),
+        include_groups=False,
     )
     real_outlier.name = "REAL_OUTLIER"
     data = data.join(real_outlier, on="OUTLIER_CURVE")

--- a/sam/exploration/tests/test_retrieve_top_n_correlations.py
+++ b/sam/exploration/tests/test_retrieve_top_n_correlations.py
@@ -15,11 +15,11 @@ class TestTopNCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "TEST_lag_0": [0, 1, 2, 3],
-                "TEST_lag_1": [np.NaN, 0, 1, 2],
-                "TEST_lag_2": [np.NaN, np.NaN, 0, 0],
+                "TEST_lag_1": [np.nan, 0, 1, 2],
+                "TEST_lag_2": [np.nan, np.nan, 0, 0],
                 "OTHER_lag_0": [3, 2, 1, 2],
-                "OTHER_lag_1": [np.NaN, 4, 2, 1],
-                "OTHER_lag_2": [np.NaN, np.NaN, 1, 1],
+                "OTHER_lag_1": [np.nan, 4, 2, 1],
+                "OTHER_lag_2": [np.nan, np.nan, 1, 1],
             }
         )
         expected = pd.DataFrame(
@@ -38,11 +38,11 @@ class TestTopNCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "TEST#lag_0": [0, 1, 2, 3],
-                "TEST#lag_1": [np.NaN, 0, 1, 2],
-                "TEST#lag_2": [np.NaN, np.NaN, 0, 1],
+                "TEST#lag_1": [np.nan, 0, 1, 2],
+                "TEST#lag_2": [np.nan, np.nan, 0, 1],
                 "OTHER#lag_0": [3, 2, 1, 0],
-                "OTHER#lag_1": [np.NaN, 3, 2, 1],
-                "OTHER#lag_2": [np.NaN, np.NaN, 3, 2],
+                "OTHER#lag_1": [np.nan, 3, 2, 1],
+                "OTHER#lag_2": [np.nan, np.nan, 3, 2],
             }
         )
 
@@ -63,14 +63,14 @@ class TestTopNCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "A": [1, 2, 4, 4, 3],
-                "A_lag_1": [np.NaN, 1, 2, 4, 4],
-                "A_lag_2": [np.NaN, np.NaN, 1, 2, 4],
+                "A_lag_1": [np.nan, 1, 2, 4, 4],
+                "A_lag_2": [np.nan, np.nan, 1, 2, 4],
                 "B": [3, 3, 3, 4, 3],
-                "B_lag_1": [np.NaN, 3, 3, 3, 4],
-                "B_lag_2": [np.NaN, np.NaN, 3, 3, 3],
+                "B_lag_1": [np.nan, 3, 3, 3, 4],
+                "B_lag_2": [np.nan, np.nan, 3, 3, 3],
                 "C": [2, 3, 1, 2, 3],
-                "C_lag_1": [np.NaN, 2, 3, 1, 2],
-                "C_lag_2": [np.NaN, np.NaN, 2, 3, 1],
+                "C_lag_1": [np.nan, 2, 3, 1, 2],
+                "C_lag_2": [np.nan, np.nan, 2, 3, 1],
             }
         )
 
@@ -91,14 +91,14 @@ class TestTopNCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "A": [1, 2, 4, 4, 3],
-                "A_lag_1": [np.NaN, 1, 2, 4, 4],
-                "A_lag_2": [np.NaN, np.NaN, 1, 2, 4],
+                "A_lag_1": [np.nan, 1, 2, 4, 4],
+                "A_lag_2": [np.nan, np.nan, 1, 2, 4],
                 "B": [3, 3, 3, 4, 3],
-                "B_lag_1": [np.NaN, 3, 3, 3, 4],
-                "B_lag_2": [np.NaN, np.NaN, 3, 3, 3],
+                "B_lag_1": [np.nan, 3, 3, 3, 4],
+                "B_lag_2": [np.nan, np.nan, 3, 3, 3],
                 "C": [2, 3, 1, 2, 3],
-                "C_lag_1": [np.NaN, 2, 3, 1, 2],
-                "C_lag_2": [np.NaN, np.NaN, 2, 3, 1],
+                "C_lag_1": [np.nan, 2, 3, 1, 2],
+                "C_lag_2": [np.nan, np.nan, 2, 3, 1],
             }
         )
 
@@ -118,8 +118,8 @@ class TestTopNCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "A": [1, 2, 4, 4, 3],
-                "A_lag_1": [np.NaN, 1, 2, 4, 4],
-                "A_lag_2": [np.NaN, np.NaN, 1, 2, 4],
+                "A_lag_1": [np.nan, 1, 2, 4, 4],
+                "A_lag_2": [np.nan, np.nan, 1, 2, 4],
             }
         )
 

--- a/sam/exploration/tests/test_retrieve_top_score_correlations.py
+++ b/sam/exploration/tests/test_retrieve_top_score_correlations.py
@@ -11,14 +11,14 @@ class TestTopCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "A": [1, 2, 4, 4, 3],
-                "A_lag_1": [np.NaN, 1, 2, 4, 4],
-                "A_lag_2": [np.NaN, np.NaN, 1, 2, 4],
+                "A_lag_1": [np.nan, 1, 2, 4, 4],
+                "A_lag_2": [np.nan, np.nan, 1, 2, 4],
                 "B": [3, 3, 3, 4, 3],
-                "B_lag_1": [np.NaN, 3, 3, 3, 4],
-                "B_lag_2": [np.NaN, np.NaN, 3, 3, 3],
+                "B_lag_1": [np.nan, 3, 3, 3, 4],
+                "B_lag_2": [np.nan, np.nan, 3, 3, 3],
                 "C": [2, 3, 1, 2, 3],
-                "C_lag_1": [np.NaN, 2, 3, 1, 2],
-                "C_lag_2": [np.NaN, np.NaN, 2, 3, 1],
+                "C_lag_1": [np.nan, 2, 3, 1, 2],
+                "C_lag_2": [np.nan, np.nan, 2, 3, 1],
             }
         )
 
@@ -36,14 +36,14 @@ class TestTopCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "A": [1, 2, 4, 4, 3],
-                "A_lag_1": [np.NaN, 1, 2, 4, 4],
-                "A_lag_2": [np.NaN, np.NaN, 1, 2, 4],
+                "A_lag_1": [np.nan, 1, 2, 4, 4],
+                "A_lag_2": [np.nan, np.nan, 1, 2, 4],
                 "B": [3, 3, 3, 4, 3],
-                "B_lag_1": [np.NaN, 3, 3, 3, 4],
-                "B_lag_2": [np.NaN, np.NaN, 3, 3, 3],
+                "B_lag_1": [np.nan, 3, 3, 3, 4],
+                "B_lag_2": [np.nan, np.nan, 3, 3, 3],
                 "C": [2, 3, 1, 2, 3],
-                "C_lag_1": [np.NaN, 2, 3, 1, 2],
-                "C_lag_2": [np.NaN, np.NaN, 2, 3, 1],
+                "C_lag_1": [np.nan, 2, 3, 1, 2],
+                "C_lag_2": [np.nan, np.nan, 2, 3, 1],
             }
         )
 
@@ -56,14 +56,14 @@ class TestTopCorrelation(unittest.TestCase):
         testserie = pd.DataFrame(
             {
                 "A": [1, 2, 4, 4, 3],
-                "A_lag_1": [np.NaN, 1, 2, 4, 4],
-                "A_lag_2": [np.NaN, np.NaN, 1, 2, 4],
+                "A_lag_1": [np.nan, 1, 2, 4, 4],
+                "A_lag_2": [np.nan, np.nan, 1, 2, 4],
                 "B": [3, 3, 3, 4, 3],
-                "B_lag_1": [np.NaN, 3, 3, 3, 4],
-                "B_lag_2": [np.NaN, np.NaN, 3, 3, 3],
+                "B_lag_1": [np.nan, 3, 3, 3, 4],
+                "B_lag_2": [np.nan, np.nan, 3, 3, 3],
                 "C": [2, 3, 1, 2, 3],
-                "C_lag_1": [np.NaN, 2, 3, 1, 2],
-                "C_lag_2": [np.NaN, np.NaN, 2, 3, 1],
+                "C_lag_1": [np.nan, 2, 3, 1, 2],
+                "C_lag_2": [np.nan, np.nan, 2, 3, 1],
             }
         )
 

--- a/sam/exploration/top_correlation.py
+++ b/sam/exploration/top_correlation.py
@@ -101,9 +101,7 @@ def top_n_correlations(
     else:
         # Add a secondary sort key on the "index" column to ensure stable, deterministic
         # ordering when correlation values are tied.
-        pos_corr = pos_corr.sort_values(
-            [goal_feature, "index"], ascending=[False, True]
-        ).head(n)
+        pos_corr = pos_corr.sort_values([goal_feature, "index"], ascending=[False, True]).head(n)
 
     corrs = df.corr()  # replace correlations with the correct negative ones
     corrs = corrs.loc[goal_feature].reset_index()

--- a/sam/exploration/top_correlation.py
+++ b/sam/exploration/top_correlation.py
@@ -69,9 +69,9 @@ def top_n_correlations(
     7           RAIN            RAIN#lag_9            -0.944911
 
     >>> top_n_correlations(res, goal_feature, n=2, grouped=False)
-                      index  DEBIET_TOTAAL#lag_0
-    0  DEBIET_TOTAAL#lag_10                 -1.0
-    1       DEBIET_A#lag_10                  1.0
+                index  DEBIET_TOTAAL#lag_0
+    0  DEBIET_A#lag_10                  1.0
+    1  DEBIET_B#lag_10                 -1.0
     """
 
     if goal_feature not in df.columns:

--- a/sam/exploration/top_correlation.py
+++ b/sam/exploration/top_correlation.py
@@ -91,7 +91,9 @@ def top_n_correlations(
         pos_corr["GROUP"] = pos_corr["index"].apply(lambda x: x.split(sep)[0])
         pos_corr = (
             pos_corr.groupby("GROUP")
-            .apply(lambda x: x.nlargest(n, goal_feature))[["index", goal_feature]]
+            .apply(lambda x: x.nlargest(n, goal_feature), include_groups=False)[
+                ["index", goal_feature]
+            ]
             .reset_index(drop=False)
         )
         pos_corr = pos_corr.drop("level_1", axis=1)

--- a/sam/exploration/top_correlation.py
+++ b/sam/exploration/top_correlation.py
@@ -69,7 +69,7 @@ def top_n_correlations(
     7           RAIN            RAIN#lag_9            -0.944911
 
     >>> top_n_correlations(res, goal_feature, n=2, grouped=False)
-                index  DEBIET_TOTAAL#lag_0
+                 index  DEBIET_TOTAAL#lag_0
     0  DEBIET_A#lag_10                  1.0
     1  DEBIET_B#lag_10                 -1.0
     """

--- a/sam/exploration/top_correlation.py
+++ b/sam/exploration/top_correlation.py
@@ -99,7 +99,11 @@ def top_n_correlations(
         pos_corr = pos_corr.drop("level_1", axis=1)
 
     else:
-        pos_corr = pos_corr.sort_values(goal_feature, ascending=False).head(n)
+        # Add a secondary sort key on the "index" column to ensure stable, deterministic
+        # ordering when correlation values are tied.
+        pos_corr = pos_corr.sort_values(
+            [goal_feature, "index"], ascending=[False, True]
+        ).head(n)
 
     corrs = df.corr()  # replace correlations with the correct negative ones
     corrs = corrs.loc[goal_feature].reset_index()

--- a/sam/feature_engineering/__init__.py
+++ b/sam/feature_engineering/__init__.py
@@ -6,7 +6,6 @@ from .weather_spei import SPEITransformer
 from .base_feature_engineering import BaseFeatureEngineer, FeatureEngineer, IdentityFeatureEngineer
 from .simple_feature_engineering import SimpleFeatureEngineer
 
-
 __all__ = [
     "decompose_datetime",
     "recode_cyclical_features",

--- a/sam/metrics/incident_recall.py
+++ b/sam/metrics/incident_recall.py
@@ -33,7 +33,7 @@ def incident_recall(
 
     Returns
     -------
-    result: float
+    result: np.float64
         The percentage of incidents that was positively predicted
 
     Examples
@@ -43,7 +43,7 @@ def incident_recall(
     >>> y_incidents = [0,1,0,0,0,0,1]
     >>> range_pred = (0,2)
     >>> incident_recall(y_incidents, y_pred, range_pred)
-    0.5
+    np.float64(0.5)
     """
     if range_pred[0] < 0 or range_pred[1] < 0:
         raise ValueError("Prediction window range_pred must be positive")
@@ -94,7 +94,7 @@ def make_incident_recall_scorer(
     >>>
     >>> scorer = make_incident_recall_scorer((1, 3), "incident")
     >>> scorer(op(), data)
-    0.6666666666666666
+    np.float64(0.6666666666666666)
     """
 
     def incident_recall_scorer(clf, X):

--- a/sam/metrics/keras_metrics.py
+++ b/sam/metrics/keras_metrics.py
@@ -99,7 +99,7 @@ def keras_joint_mse_tilted_loss(
         quantiles = []
     # select the last column (nodes) of the output
     k = len(quantiles)
-    
+
     # slice(x, start_indices, shape)
     mean_pred = K.slice(y_pred, [0, k * n_targets], [-1, n_targets])
     # The last node will be fit with regular mean squared error

--- a/sam/metrics/keras_metrics.py
+++ b/sam/metrics/keras_metrics.py
@@ -8,7 +8,6 @@ try:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=DeprecationWarning)
         warnings.simplefilter("ignore", category=FutureWarning)
-        import tensorflow as tf
         import keras.ops as K
 except ImportError:
     # These are optional dependencies so it's not necessary to crash if they aren't found.

--- a/sam/metrics/keras_metrics.py
+++ b/sam/metrics/keras_metrics.py
@@ -9,14 +9,14 @@ try:
         warnings.simplefilter("ignore", category=DeprecationWarning)
         warnings.simplefilter("ignore", category=FutureWarning)
         import tensorflow as tf
-        import tensorflow.keras.backend as K
+        import keras.ops as K
 except ImportError:
     # These are optional dependencies so it's not necessary to crash if they aren't found.
     # However, this will crash once one of the functions below runs.
     pass
 
 
-def keras_tilted_loss(y_true: tf.Tensor, y_pred: tf.Tensor, quantile: float = 0.5):
+def keras_tilted_loss(y_true, y_pred, quantile: float = 0.5):
     """
     Calculate tilted, or quantile loss in Keras. Given a quantile q, and an error e,
     tilted loss is defined as `(1-q) * |e|` if `e < 0`, and `q * |e|` if `e > 0`.
@@ -27,9 +27,9 @@ def keras_tilted_loss(y_true: tf.Tensor, y_pred: tf.Tensor, quantile: float = 0.
 
     Parameters
     ----------
-    y_true: Theano/TensorFlow tensor.
+    y_true: tensor
         True labels.
-    y_pred: Theano/TensorFlow tensor.
+    y_pred: tensor
         Predictions. Must be same shape as `y_true`
     quantile: float, optional (default=0.5)
         The quantile to use when computing tilted loss.
@@ -52,16 +52,15 @@ def keras_tilted_loss(y_true: tf.Tensor, y_pred: tf.Tensor, quantile: float = 0.
 
 
 def keras_joint_mse_tilted_loss(
-    y_true: tf.Tensor,
-    y_pred: tf.Tensor,
+    y_true,
+    y_pred,
     quantiles: List[float] = None,
     n_targets: int = 1,
 ):
     """
     Joint mean and quantile regression loss function using mse.
     Sum of mean squared error and multiple tilted loss functions
-    Custom loss function, inspired by https://github.com/fmpr/DeepJMQR
-    Only compatible with tensorflow backend.
+    Custom loss function, inspired by https://github.com/fmpr/DeepJMQR.
 
     This calculates loss for multiple quantiles, and multiple targets.
     The total loss is the sum of the mse of all targets, and the tilted
@@ -75,9 +74,9 @@ def keras_joint_mse_tilted_loss(
 
     Parameters
     ----------
-    y_true: tensorflow tensor
+    y_true: tensor
         True values
-    y_pred: tensorflow tensor
+    y_pred: tensor
         Predicted values
     quantiles: list of floats (default=None)
         Quantiles to predict. Values between 0 and 1. By default, no quantile loss is used.
@@ -100,14 +99,16 @@ def keras_joint_mse_tilted_loss(
         quantiles = []
     # select the last column (nodes) of the output
     k = len(quantiles)
-    mean_pred = tf.slice(y_pred, [0, k * n_targets], [-1, n_targets])
+    
+    # slice(x, start_indices, shape)
+    mean_pred = K.slice(y_pred, [0, k * n_targets], [-1, n_targets])
     # The last node will be fit with regular mean squared error
     loss = K.sum(K.mean(K.square(y_true - mean_pred), axis=0), axis=-1)
     # For each quantile fit one node with corresponding tilted loss
     for k in range(len(quantiles)):
         q = quantiles[k]
         # Select the kth node
-        q_pred = tf.slice(y_pred, [0, k * n_targets], [-1, n_targets])
+        q_pred = K.slice(y_pred, [0, k * n_targets], [-1, n_targets])
         e = y_true - q_pred
         # add tilted loss to total loss
         loss += K.sum(K.mean(K.maximum(q * e, (q - 1) * e), axis=0), axis=-1)
@@ -115,15 +116,14 @@ def keras_joint_mse_tilted_loss(
 
 
 def keras_joint_mae_tilted_loss(
-    y_true: tf.Tensor,
-    y_pred: tf.Tensor,
+    y_true,
+    y_pred,
     quantiles: List[float] = None,
     n_targets: int = 1,
 ):
     """Joint mean and quantile regression loss function using mae.
     Sum of mean absolute error and multiple tilted loss functions
-    Custom loss function, inspired by https://github.com/fmpr/DeepJMQR
-    Only compatible with tensorflow backend.
+    Custom loss function, inspired by https://github.com/fmpr/DeepJMQR.
 
     This calculates loss for multiple quantiles, and multiple targets.
     The total loss is the sum of the mae of all targets, and the tilted
@@ -137,9 +137,9 @@ def keras_joint_mae_tilted_loss(
 
     Parameters
     ----------
-    y_true: tensorflow tensor
+    y_true: tensor
         True values
-    y_pred: tensorflow tensor
+    y_pred: tensor
         Predicted values
     quantiles: list of floats (default=None)
         Quantiles to predict. Values between 0 and 1. By default, no quantile loss is used.
@@ -162,29 +162,29 @@ def keras_joint_mae_tilted_loss(
         quantiles = []
     # select the last column (nodes) of the output
     k = len(quantiles)
-    mean_pred = tf.slice(y_pred, [0, k * n_targets], [-1, n_targets])
+    mean_pred = K.slice(y_pred, [0, k * n_targets], [-1, n_targets])
     # The last node will be fit with 0.5 quantile
-    loss = K.sum(K.mean(K.abs(y_true - mean_pred), axis=0), axis=-1)
+    loss = K.sum(K.mean(K.absolute(y_true - mean_pred), axis=0), axis=-1)
     # For each quantile fit one node with corresponding tilted loss
     for k in range(len(quantiles)):
         q = quantiles[k]
         # Select the kth node
-        q_pred = tf.slice(y_pred, [0, k * n_targets], [-1, n_targets])
+        q_pred = K.slice(y_pred, [0, k * n_targets], [-1, n_targets])
         e = y_true - q_pred
         # add tilted loss to total loss
         loss += K.sum(K.mean(K.maximum(q * e, (q - 1) * e), axis=0), axis=-1)
     return loss
 
 
-def keras_rmse(y_true: tf.Tensor, y_pred: tf.Tensor):
+def keras_rmse(y_true, y_pred):
     """
     Calculate root mean squared error in Keras.
 
     Parameters
     ----------
-    y_true: Theano/TensorFlow tensor.
+    y_true: tensor
         True labels.
-    y_pred: Theano/TensorFlow tensor.
+    y_pred: tensor
         Predictions. Must be same shape as `y_true`
 
     Examples

--- a/sam/metrics/mase.py
+++ b/sam/metrics/mase.py
@@ -50,7 +50,7 @@ def mean_absolute_scaled_error(
 
     Returns
     -------
-    loss: float or ndarray of floats
+    loss: np.float64 or ndarray of floats
         MASE output is non-negative floating point. The best value is 0.0.
 
     Examples
@@ -59,7 +59,7 @@ def mean_absolute_scaled_error(
     >>> y_pred = [0.5, 1.5, 2.5]
     >>> # persistence benchmark would have a loss of 1. Our prediction has a loss of 0.5
     >>> mean_absolute_scaled_error(y_true, y_pred, shift=1)
-    0.5
+    np.float64(0.5)
     """
     if shift != int(shift) or shift <= 0:
         raise ValueError("Shift must be a positive integer")

--- a/sam/metrics/tilted_loss_metrics.py
+++ b/sam/metrics/tilted_loss_metrics.py
@@ -109,7 +109,7 @@ def joint_mae_tilted_loss(
     ...     columns=["output_1_quantile_1", "output_1_quantile_2", "output_1_mean"],
     ... )
     >>> joint_mae_tilted_loss(y_true, y_pred, quantiles=[0.1, 0.9], n_targets=1)
-    np.float(3.44)
+    np.float64(3.44)
     """
     if quantiles is None:
         quantiles = []

--- a/sam/metrics/tilted_loss_metrics.py
+++ b/sam/metrics/tilted_loss_metrics.py
@@ -43,7 +43,7 @@ def tilted_loss(y_true: np.ndarray, y_pred: np.ndarray, quantile: float = 0.5, a
 
     Returns
     -------
-    float:
+    np.float64:
         The quantile loss
 
     Examples
@@ -53,7 +53,7 @@ def tilted_loss(y_true: np.ndarray, y_pred: np.ndarray, quantile: float = 0.5, a
     >>> actual = np.array([1, 2, 3, 4])
     >>> pred = np.array([0.9, 2.1, 2.9, 3.1])
     >>> tilted_loss(actual, pred, quantile=0.5)
-    0.15000000000000002
+    np.float64(0.15000000000000002)
     """
     y_true, y_pred = np.array(y_true), np.array(y_pred)
     e = y_true - y_pred
@@ -95,7 +95,7 @@ def joint_mae_tilted_loss(
 
     Returns
     -------
-    float:
+    np.float64:
         The joint mae tilted loss
 
     Examples
@@ -109,7 +109,7 @@ def joint_mae_tilted_loss(
     ...     columns=["output_1_quantile_1", "output_1_quantile_2", "output_1_mean"],
     ... )
     >>> joint_mae_tilted_loss(y_true, y_pred, quantiles=[0.1, 0.9], n_targets=1)
-    3.44
+    np.float(3.44)
     """
     if quantiles is None:
         quantiles = []
@@ -160,7 +160,7 @@ def joint_mse_tilted_loss(
 
     Returns
     -------
-    float:
+    np.float64:
         The joint mse tilted loss
 
     Examples
@@ -174,7 +174,7 @@ def joint_mse_tilted_loss(
     ...     columns=["output_1_quantile_1", "output_1_quantile_2", "output_1_mean"],
     ... )
     >>> joint_mse_tilted_loss(y_true, y_pred, quantiles=[0.1, 0.9], n_targets=1)
-    7.410000000000002
+    np.float64(7.410000000000002)
     """
     if quantiles is None:
         quantiles = []

--- a/sam/models/keras_templates.py
+++ b/sam/models/keras_templates.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional
 
-from keras import Optimizer
+from keras.optimizers import Optimizer
 
 from sam.metrics import keras_joint_mae_tilted_loss, keras_joint_mse_tilted_loss
 
@@ -82,15 +82,15 @@ def create_keras_quantile_mlp(
     >>> model.fit(X, y, batch_size=16, epochs=20, verbose=0)  # doctest: +ELLIPSIS
     <keras.src.callbacks.history.History ...
     """
-    from tensorflow.keras.layers import (
+    from keras.layers import (
         Activation,
         BatchNormalization,
         Dense,
         Dropout,
         Input,
     )
-    from tensorflow.keras.models import Model
-    from tensorflow.keras.optimizers import Adam
+    from keras.models import Model
+    from keras.optimizers import Adam
 
     if quantiles is None:
         quantiles = []
@@ -207,9 +207,9 @@ def create_keras_quantile_rnn(
     >>> model.fit(X_3d, y, batch_size=32, epochs=5, verbose=0)  # doctest: +ELLIPSIS
     <keras.src.callbacks.history.History ...
     """
-    from tensorflow.keras.layers import GRU, LSTM, Dense, Input
-    from tensorflow.keras.models import Model
-    from tensorflow.keras.optimizers import Adam
+    from keras.layers import GRU, LSTM, Dense, Input
+    from keras.models import Model
+    from keras.optimizers import Adam
 
     if quantiles is None:
         quantiles = []
@@ -315,15 +315,15 @@ def create_keras_autoencoder_mlp(
     >>> model.fit(X.T, X.T, batch_size=32, epochs=5, verbose=0)  # doctest: +ELLIPSIS
     <keras.src.callbacks.history.History ...
     """
-    from tensorflow.keras.layers import (
+    from keras.layers import (
         Activation,
         BatchNormalization,
         Dense,
         Dropout,
         Input,
     )
-    from tensorflow.keras.models import Model
-    from tensorflow.keras.optimizers import Adam
+    from keras.models import Model
+    from keras.optimizers import Adam
 
     if dropout is None:
         dropout = 0.0
@@ -420,7 +420,7 @@ def create_keras_autoencoder_rnn(
     >>> model.fit(X_3d, X_3d, batch_size=32, epochs=5, verbose=0)  # doctest: +ELLIPSIS
     <keras.src.callbacks.history.History ...
     """
-    from tensorflow.keras.layers import (
+    from keras.layers import (
         GRU,
         LSTM,
         Dense,
@@ -428,8 +428,8 @@ def create_keras_autoencoder_rnn(
         RepeatVector,
         TimeDistributed,
     )
-    from tensorflow.keras.models import Model
-    from tensorflow.keras.optimizers import Adam
+    from keras.models import Model
+    from keras.optimizers import Adam
 
     if dropout is None:
         dropout = 0.0

--- a/sam/models/mlp_model.py
+++ b/sam/models/mlp_model.py
@@ -3,7 +3,8 @@ from typing import Callable, Sequence, Tuple, Union, Optional, Any
 
 import numpy as np
 import pandas as pd
-from keras import Optimizer, Model
+from keras.optimizers import Optimizer
+from keras.models import Model
 from sklearn.pipeline import Pipeline
 
 from sam.feature_engineering import BaseFeatureEngineer

--- a/sam/models/tests/conftest.py
+++ b/sam/models/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+os.environ["KERAS_BACKEND"] = "tensorflow"
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+import pytest

--- a/sam/models/tests/conftest.py
+++ b/sam/models/tests/conftest.py
@@ -2,4 +2,3 @@ import os
 
 os.environ["KERAS_BACKEND"] = "tensorflow"
 os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
-import pytest

--- a/sam/models/tests/conftest.py
+++ b/sam/models/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ["KERAS_BACKEND"] = "tensorflow"
 os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 import pytest

--- a/sam/models/tests/test_mlp_model.py
+++ b/sam/models/tests/test_mlp_model.py
@@ -99,7 +99,7 @@ def test_mlp(
 
 class TestOptimizer(unittest.TestCase):
     def test_default_optimizer(self):
-        from keras.src.optimizers import Adam
+        from keras.optimizers import Adam
 
         X, y = get_dataset()
         fe = SimpleFeatureEngineer(keep_original=True)
@@ -126,7 +126,7 @@ class TestOptimizer(unittest.TestCase):
         )
 
     def test_overwrite_optimizer(self):
-        from keras.src.optimizers import AdamW
+        from keras.optimizers import AdamW
 
         X, y = get_dataset()
         fe = SimpleFeatureEngineer(keep_original=True)

--- a/sam/models/tests/utils.py
+++ b/sam/models/tests/utils.py
@@ -13,12 +13,14 @@ def set_seed(func):
     def wrapper(*args, **kwargs):
         try:
             import keras
+
             keras.utils.set_random_seed(42)
             # Make sure to set output to be deterministic
             os.environ["TF_DETERMINISTIC_OPS"] = "1"
         except ImportError:
             try:
                 import tensorflow as tf
+
                 tf.random.set_seed(42)
             except ImportError:
                 pass
@@ -26,7 +28,7 @@ def set_seed(func):
             random.seed(42)
             np.random.seed(42)
             os.environ["PYTHONHASHSEED"] = "0"
-            
+
         return func(*args, **kwargs)
 
     return wrapper

--- a/sam/models/tests/utils.py
+++ b/sam/models/tests/utils.py
@@ -12,15 +12,21 @@ def set_seed(func):
 
     def wrapper(*args, **kwargs):
         try:
-            import tensorflow as tf
-
-            tf.random.set_seed(42)
+            import keras
+            keras.utils.set_random_seed(42)
+            # Make sure to set output to be deterministic
+            os.environ["TF_DETERMINISTIC_OPS"] = "1"
         except ImportError:
-            pass
+            try:
+                import tensorflow as tf
+                tf.random.set_seed(42)
+            except ImportError:
+                pass
 
-        random.seed(42)
-        np.random.seed(42)
-        os.environ["PYTHONHASHSEED"] = "0"
+            random.seed(42)
+            np.random.seed(42)
+            os.environ["PYTHONHASHSEED"] = "0"
+            
         return func(*args, **kwargs)
 
     return wrapper

--- a/sam/preprocessing/tests/test_normalize_timestamps.py
+++ b/sam/preprocessing/tests/test_normalize_timestamps.py
@@ -34,7 +34,7 @@ class TestCompleteTimestamps(unittest.TestCase):
         result = normalize_timestamps(data, "15min", start_time, end_time)
 
         # Values are matched to their first right side matching time,
-        # so the first value is np.NaN
+        # so the first value is np.nan
         output = pd.DataFrame(
             {
                 "TIME": pd.to_datetime(
@@ -84,7 +84,7 @@ class TestCompleteTimestamps(unittest.TestCase):
         result2 = normalize_timestamps(data, "15min", start_time2, end_time2)
 
         # Values are matched to their first left side matching time,
-        # so the last value is np.NaN
+        # so the last value is np.nan
         output = pd.DataFrame(
             {
                 "TIME": pd.to_datetime(
@@ -264,7 +264,7 @@ class TestCompleteTimestamps(unittest.TestCase):
                 ),
                 "ID": [1, 1, 1, 2, 2, 2],
                 "TYPE": 2,
-                "VALUE": [1.0, 2.0, np.NaN, 3.0, np.NaN, 4.0],
+                "VALUE": [1.0, 2.0, np.nan, 3.0, np.nan, 4.0],
             },
             columns=["TIME", "ID", "TYPE", "VALUE"],
         )
@@ -346,7 +346,7 @@ class TestCompleteTimestamps(unittest.TestCase):
                 ),
                 "ID": 1,
                 "TYPE": [1, 1, 1, 2, 2, 2],
-                "VALUE": [1, 2, np.NaN, 3, np.NaN, 4],
+                "VALUE": [1, 2, np.nan, 3, np.nan, 4],
             },
             columns=["TIME", "ID", "TYPE", "VALUE"],
         )
@@ -386,7 +386,7 @@ class TestCompleteTimestamps(unittest.TestCase):
                 ),
                 "ID": 1,
                 "TYPE": [1, 1, 1, 2, 2, 2],
-                "VALUE": [1, 2, np.NaN, 3, np.NaN, 4],
+                "VALUE": [1, 2, np.nan, 3, np.nan, 4],
             },
             columns=["TIME", "ID", "TYPE", "VALUE"],
         )


### PR DESCRIPTION
- Remove support for python 3.9 and 3.10, and add support for 3.12.
- User Keras directly instead of tensorflow wrapper. This triggered some changes in the types of the docstrings.
- Use numpy 2.
- Fix a few deprecation warnings.